### PR TITLE
ASL Rewrite

### DIFF
--- a/CCFF7R.asl
+++ b/CCFF7R.asl
@@ -6,6 +6,7 @@ state("CCFF7R-Win64-Shipping")
   double IGT: 0x71B3FB8;              //IGT
   uint EXP: 0x71B3F04;                //EXP (Default Value on Title Screen is 489)
   byte Chapter: 0x71B4BA4;            //Gives current chapter number (0 during prologue and some loading screens)
+  uint CursedRing: 0x71B5068;         //Cursed ring chest attempt count, 20 == cursed ring obtained
   uint Enemy1HP: 0x7195028;           //First enemy current HP
   uint Enemy1MaxHP: 0x719502C;        //First enemy maximum HP
   uint Enemy2HP: 0x7195768;           //Second enemy current HP
@@ -77,9 +78,12 @@ startup
   //Misc Splits
   settings.Add("misc", false, "Misc Splits");
   settings.CurrentDefaultParent = "misc";
-  settings.Add("misc713", false, "Mission 7-1-3");
-  settings.Add("misc722", false, "Mission 7-2-2");
-  settings.Add("miscwalletworms", false, "Wallet Worms");
+  settings.Add("misc713", false, "Mission 7-1-3");                      // Combat resolved - boss encounter 7 - 1 - 3
+  settings.Add("misc722", false, "Mission 7-2-2");                      // Combat resolved - boss encounter 7 - 2 - 2
+  settings.Add("miscwalletworms", false, "Wallet Worms");               // Combat resolved - 3 worms for wallet quest
+  settings.Add("miscwutaiinfiltrate", false, "Wutai Camp Infiltration");// combat resolved - first encounter after going through wutai camp gates
+  settings.Add("miscwutaicampcleared", false, "Wutai Camp Cleared");    // combat resolved - after clearning the 3 Foulanders in wutai camp
+  settings.Add("misccursedring", false, "Cursed Ring");                 // upon dialogue after clicking the chest for the cursed ring for the 20th time
   settings.CurrentDefaultParent = null;
 }
 
@@ -215,6 +219,25 @@ split
         current.Enemy1HP < 1 && current.Enemy2HP < 1 && current.Enemy3HP < 1)
     {
       vars.CompletedMiscList.Add(2);
+      return true;
+    }
+    if(!vars.CompletedMiscList.Contains(3) && settings["misccursedring"] && current.CursedRing == 20 && current.Chapter == 1)
+    {
+      vars.CompletedMiscList.Add(3);
+      return true;
+    }
+    if(!vars.CompletedMiscList.Contains(4) && settings["miscwutaiinfiltrate"] && current.Chapter == 1 &&
+        (current.Enemy1MaxHP == 575 && current.Enemy2MaxHP == 178 && current.Enemy3MaxHP == 178 && current.Enemy4MaxHP == 0) &&
+        (current.Enemy1HP < 1 && current.Enemy2HP < 1 && current.Enemy3HP < 1))
+    {
+      vars.CompletedMiscList.Add(4);
+      return true;
+    }
+    if(!vars.CompletedMiscList.Contains(5) && settings["miscwutaicampcleared"] && current.Chapter == 1 &&
+        (current.Enemy1MaxHP == 482 && current.Enemy2MaxHP == 482 && current.Enemy3MaxHP == 482) &&
+        (current.Enemy1HP < 1 && current.Enemy2HP < 1 && current.Enemy3HP < 1))
+    {
+      vars.CompletedMiscList.Add(5);
       return true;
     }
   }

--- a/CCFF7R.asl
+++ b/CCFF7R.asl
@@ -106,6 +106,7 @@ startup
 
 update 
 {
+  print("Hello?");
   if(vars.crash) { vars.timer++; }                                    // Increment timer if game is closed          
   if(vars.timer >= 3600 || current.Loading1) { vars.crash = false; }  // 60 seconds timer or loading screen resets crash
 
@@ -213,5 +214,11 @@ exit
 }
 
 start { return current.LevelId == 21; }
-reset { return current.MenuState == 54 && current.PauseState == 2 }
+reset {
+  if(current.MenuState == 54 && current.PauseState == 2) {
+    vars.crash = false;
+    vars.timer = 0;
+    return true;
+  }
+}
 isLoading { return current.Loading1 || current.Loading2 || vars.crash; }

--- a/CCFF7R.asl
+++ b/CCFF7R.asl
@@ -179,13 +179,11 @@ split
 
   // Cutscenes push us from 62->60 so we need to have descended Mt Nibel before allowing the split
   if(current.LevelId == 56 && vars.Location == 61){
-    print("Decent complete!!!");
     vars.DecendedMtn = true;
   }
 
   // LevelId switches between 0 and the level, ignore 0's
   if(current.LevelId != 0 && current.LevelId != vars.Location) {
-    print("Location: " + current.LevelId.ToString());
     vars.Location = current.LevelId;
   }
 }

--- a/CCFF7R.asl
+++ b/CCFF7R.asl
@@ -106,7 +106,6 @@ startup
 
 update 
 {
-  print("Hello?");
   if(vars.crash) { vars.timer++; }                                    // Increment timer if game is closed          
   if(vars.timer >= 3600 || current.Loading1) { vars.crash = false; }  // 60 seconds timer or loading screen resets crash
 
@@ -214,11 +213,11 @@ exit
 }
 
 start { return current.LevelId == 21; }
-reset {
-  if(current.MenuState == 54 && current.PauseState == 2) {
-    vars.crash = false;
-    vars.timer = 0;
-    return true;
-  }
-}
+// reset {
+//   if(current.MenuState == 54 && current.PauseState == 2) {
+//     vars.crash = false;
+//     vars.timer = 0;
+//     return true;
+//   }
+// }
 isLoading { return current.Loading1 || current.Loading2 || vars.crash; }

--- a/CCFF7R.asl
+++ b/CCFF7R.asl
@@ -45,9 +45,9 @@ startup
   settings.Add("bosses", false, "Bosses");
   settings.CurrentDefaultParent = "bosses";
   settings.Add("e13", false, "Behemoth");
-  settings.Add("e90,93", false, "Vajradhara Twins");
+  settings.Add("e346,349", false, "Vajradhara Twins");
   settings.Add("e196", false, "Ifrit");
-  settings.Add("e25", false, "Guard Spider");
+  settings.Add("e281", false, "Guard Spider");
   settings.Add("e9", false, "Bahamut");
   settings.Add("e107", false, "G Eraser");
   settings.Add("e57,61,64", false, "Machine Trio");
@@ -114,9 +114,9 @@ split
   if(current.ZackHP > 0 && current.BattleState == 6 && old.BattleState != 6){
     if(settings["e13"] && current.EnemyId1 == 13) { return true; }
     if(settings["e92,92,92"] && current.EnemyId1 == 92 && current.EnemyId2 == 92 && current.EnemyId3 == 92) { return true; }
-    if(settings["e90,93"] && current.EnemyId1 == 90 && current.EnemyId2 == 93) { return true; }
+    if(settings["e346,349"] && current.EnemyId1 == 346 && current.EnemyId2 == 349) { return true; }
     if(settings["e196"] && current.EnemyId1 == 196) { return true; }
-    if(settings["e25"] && current.EnemyId1 == 25) { return true; }
+    if(settings["e281"] && current.EnemyId1 == 281) { return true; }
     if(settings["e9"] && current.EnemyId1 == 9) { return true; }
     if(settings["e178,178"] && current.EnemyId1 == 178 && current.EnemyId2 == 178) { return true; }
     if(settings["e257,257,52"] && current.EnemyId1 == 257 && current.EnemyId2 == 257 && current.EnemyId3 == 52) { return true; }

--- a/CCFF7R.asl
+++ b/CCFF7R.asl
@@ -4,8 +4,6 @@ state("CCFF7R-Win64-Shipping")
   bool Loading2: 0x04D8D5F0, 0x7D;    //1 when cutscene is loaded
   byte Chapter: 0x71B4BA4;            //Gives current chapter number (0 during prologue and some loading screens)
   uint BattleState: 0x717AD5C;        //Battle state incrementing from 0-7
-  uint MenuState: 0x73A0BD0;          //Menu state 54 when in confirm new game window
-  uint PauseState: 0x73F2734;         //Pause menu state, 3 when in pause menu, 2 otherwise
   uint LevelId: 0x717A5AC;            //Sometimes 0
   uint CursedRing: 0x71B5068;         //Cursed ring chest attempts
 
@@ -213,11 +211,4 @@ exit
 }
 
 start { return current.LevelId == 21; }
-// reset {
-//   if(current.MenuState == 54 && current.PauseState == 2) {
-//     vars.crash = false;
-//     vars.timer = 0;
-//     return true;
-//   }
-// }
 isLoading { return current.Loading1 || current.Loading2 || vars.crash; }


### PR DESCRIPTION
## Timing Differences

The old ASL splits on encounters when all enemy HPs are 0
The new ASL splits when the encounter presents the "Conflict Resolved" message

If a Materia or Zack level up is earned at the end of battle, it will delay the next time the player can have inputs register on Zack by ~2 Seconds
If we decide to split on the HP of the enemy being 0, then the next split will be 2 seconds slower regardless of a perfect split


 
|  Materia Level up: |  https://youtu.be/adtGyIVJ7cM?t=3001 |
|---|---|
Final Blow              | 44:25.77  |
Level up Hidden         | 44:28.04  |
Conflict Resolved Hidden  | 44:29.66  |
Elapsed                 | 3.89s     |


|  No Level up: |  https://www.twitch.tv/videos/1710389455?t=1h9m40s |
|---|---|
Final Blow                  | 49:04.31  |
Conflict Resolved Hidden      | 49:07.17  |
Elapsed                     | 1.86s     |


If we are aiming of accuracy the new way is objectively more accurate... but I do understand the headaches of retiming or deleting previously earned gold splits.

## Splits

Below is a table of splits that are available in the new ASL
The only Exception is Genesis 2 who's split will be at HP 0 to conform with the rules
The order is based on the any% route
The "data" column represents the ID's we check in memory
- Encounter: CSV of Enemy ID's in order, 4,6,8 = Enemy 0 ID: 4, Enemy 1 ID: 6 etc
- Location: CSV or Singular of Location ID, 1,2 = moving from location 1 to location 2


| Name                     | Type      | Data            |
|--------------------------|-----------|-----------------|
| Behemoth                 | Encounter | 13              |
| Prologue                 | Chapter   | 0,1             |
| Cursed Ring              | Unique    | 20              |
| Enter Fort Wutai         | Location  | 90              |
| Clear Fort Wutai         | Encounter | 92,92,92        |
| Vajradhara Twins         | Encounter | 90,93           |
| Ifrit                    | Encounter | 196             |
| Chapter 1                | Chapter   | 0,1             |
| Guard Spider             | Encounter | 25              |
| Bahamut                  | Encounter | 9               |
| Chapter 2                | Chapter   | 1,2             |
| Mission 7-1-1            | Encounter | 178,178         |
| Mission 7-1-2            | Encounter | 257,257,52      |
| Mission 7-1-3            | Encounter | 257,257,257,179 |
| G Eraser                 | Encounter | 107             |
| Machine Trio             | Encounter | 57,61,64        |
| Chapter 3                | Chapter   | 2,3             |
| Mission 7-2-1            | Encounter | 52,107          |
| Mission 7-2-2            | Encounter | 283             |
| Wallet Worms             | Encounter | 286,286,286     |
| G Warrior                | Encounter | 115             |
| Bahamut Fury             | Encounter | 10              |
| Chapter 4                | Chapter   | 4,5             |
| Genesis I                | Encounter | 137             |
| A-Griffon                | Encounter | 149             |
| Angeal Penance           | Encounter | 204             |
| Chapter 5                | Chapter   | 5,6             |
| General's Tank           | Encounter | 336             |
| Prototype Guard Scorpion | Encounter | 278             |
| Chapter 6                | Chapter   | 6,7             |
| Chapter 7                | Chapter   | 7,8             |
| Mt. Nibel Descent        | Location  | 61,37           |
| Shinra Manor             | Location  | 65              |
| Mt. Nibel Ascent         | Location  | 62,60           |
| Sephiroth I              | Encounter | 295             |
| Sephiroth II             | Encounter | 296             |
| Chapter 8                | Chapter   | 8,9             |
| Save Cloud               | Location  | 67              |
| G Eliminator             | Encounter | 122             |
| Gongaga Hilltop          | Encounter | 111,119         |
| Hollander                | Encounter | 183             |
| Chapter 9                | Chapter   | 9,10            |
| G Regicide               | Encounter | 124             |
| Genesis Avatar           | Encounter | 206             |
| Genesis II               | Encounter | 139             |
|                          |           |                 |
| Minerva                  | Encounter | 220             |

---

There is a bug in the old and new ASL where if a runner restarts their game then resets their timer the autosplitter still thinks it's in a crashed state and will not start the timer on a new run. There's no real easy way to fix this until an autoreset is implemented

Fixes https://github.com/desa35/CCFF7R-Loadremover/issues/4